### PR TITLE
[Chore] Using the correct status code in auth tests

### DIFF
--- a/test/microcontroller_server/services/auth_services/microcontroller_auth_service_test.exs
+++ b/test/microcontroller_server/services/auth_services/microcontroller_auth_service_test.exs
@@ -3,7 +3,7 @@ defmodule MicrocontrollerServer.Services.AuthServices.MicrocontrollerAuthService
 
   import Mox
 
-  alias HTTPoison.{Response, Error}
+  alias HTTPoison.Response
 
   doctest MicrocontrollerServer.Services.AuthServices.MicrocontrollerAuthService, import: true
 


### PR DESCRIPTION
Updated the mock case of the API server to give a status code 401 when it is not correct.